### PR TITLE
Update Cocoapods 1.10.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'cocoapods'
+  gem 'cocoapods', '~>1.10.1'
 
   gem 'mocha'
   gem 'bacon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cocoapods-binary (0.4.4)
-      cocoapods (>= 1.5.0, < 2.0)
+      cocoapods (~> 1.10.1)
       fourflusher (~> 2.0)
       xcpretty (~> 0.3.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.3)
-    activesupport (5.2.4.4)
+    activesupport (5.2.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -23,10 +23,10 @@ GEM
     atomos (0.1.3)
     bacon (1.2.0)
     claide (1.0.3)
-    cocoapods (1.10.0)
+    cocoapods (1.10.1)
       addressable (~> 2.6)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.10.0)
+      cocoapods-core (= 1.10.1)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 1.4.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -41,7 +41,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (~> 1.4)
       xcodeproj (>= 1.19.0, < 2.0)
-    cocoapods-core (1.10.0)
+    cocoapods-core (1.10.1)
       activesupport (> 5.0, < 6)
       addressable (~> 2.6)
       algoliasearch (~> 1.0)
@@ -61,20 +61,20 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     escape (0.0.4)
     ethon (0.12.0)
       ffi (>= 1.3.0)
-    ffi (1.13.1)
+    ffi (1.15.0)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.8.3)
-    i18n (1.8.5)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    json (2.3.1)
-    minitest (5.14.2)
-    mocha (1.11.2)
+    json (2.5.1)
+    minitest (5.14.4)
+    mocha (1.12.0)
     mocha-on-bacon (0.2.3)
       mocha (>= 0.13.0)
     molinillo (0.6.6)
@@ -84,13 +84,13 @@ GEM
     prettybacon (0.0.2)
       bacon (~> 1.2)
     public_suffix (4.0.6)
-    rake (13.0.1)
+    rake (13.0.3)
     rouge (2.0.7)
     ruby-macho (1.4.0)
     thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.8)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     xcodeproj (1.19.0)
       CFPropertyList (>= 2.3.3, < 4.0)
@@ -107,7 +107,7 @@ PLATFORMS
 DEPENDENCIES
   bacon
   bundler (> 1.3)
-  cocoapods
+  cocoapods (~> 1.10.1)
   cocoapods-binary!
   mocha
   mocha-on-bacon
@@ -115,4 +115,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   2.1.4
+   2.2.15

--- a/cocoapods-binary.gemspec
+++ b/cocoapods-binary.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency "cocoapods", ">= 1.5.0", "< 2.0"
+  spec.add_dependency "cocoapods", "~> 1.10.1"
   spec.add_dependency "fourflusher", "~> 2.0"
   spec.add_dependency "xcpretty", "~> 0.3.0"
 


### PR DESCRIPTION
To set cocoapods version to 1.10.1 for cocoapods binary project