### PR TITLE
Update Cocoapods to 1.12.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'cocoapods', '~>1.11.2'
+  gem 'cocoapods', '~>1.12.1'
 
   gem 'mocha'
   gem 'bacon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,38 +2,37 @@ PATH
   remote: .
   specs:
     cocoapods-binary (0.4.5)
-      cocoapods (~> 1.11.2)
+      cocoapods (~> 1.12.1)
       fourflusher (~> 2.0)
       xcpretty (~> 0.3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.5)
+    CFPropertyList (3.0.6)
       rexml
-    activesupport (6.1.4.4)
+    activesupport (7.0.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
     bacon (1.2.0)
-    claide (1.0.3)
-    cocoapods (1.11.2)
+    claide (1.1.0)
+    cocoapods (1.12.1)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.11.2)
+      cocoapods-core (= 1.12.1)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 1.4.0, < 2.0)
+      cocoapods-downloader (>= 1.6.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
-      cocoapods-trunk (>= 1.4.0, < 2.0)
+      cocoapods-trunk (>= 1.6.0, < 2.0)
       cocoapods-try (>= 1.1.0, < 2.0)
       colored2 (~> 3.1)
       escape (~> 0.0.4)
@@ -41,10 +40,10 @@ GEM
       gh_inspector (~> 1.0)
       molinillo (~> 0.8.0)
       nap (~> 1.0)
-      ruby-macho (>= 1.0, < 3.0)
+      ruby-macho (>= 2.3.0, < 3.0)
       xcodeproj (>= 1.21.0, < 2.0)
-    cocoapods-core (1.11.2)
-      activesupport (>= 5.0, < 7)
+    cocoapods-core (1.12.1)
+      activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
       concurrent-ruby (~> 1.1)
@@ -54,7 +53,7 @@ GEM
       public_suffix (~> 4.0)
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.5)
-    cocoapods-downloader (1.5.1)
+    cocoapods-downloader (1.6.3)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.1)
@@ -63,19 +62,19 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.2.2)
     escape (0.0.4)
-    ethon (0.15.0)
+    ethon (0.16.0)
       ffi (>= 1.15.0)
-    ffi (1.15.4)
+    ffi (1.15.5)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.8.3)
-    i18n (1.8.11)
+    i18n (1.13.0)
       concurrent-ruby (~> 1.0)
-    json (2.6.1)
-    minitest (5.15.0)
+    json (2.6.3)
+    minitest (5.18.0)
     mocha (1.13.0)
     mocha-on-bacon (0.2.3)
       mocha (>= 0.13.0)
@@ -85,16 +84,16 @@ GEM
     netrc (0.11.0)
     prettybacon (0.0.2)
       bacon (~> 1.2)
-    public_suffix (4.0.6)
+    public_suffix (4.0.7)
     rake (13.0.6)
     rexml (3.2.5)
     rouge (2.0.7)
     ruby-macho (2.5.1)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.21.0)
+    xcodeproj (1.22.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -103,7 +102,6 @@ GEM
       rexml (~> 3.2.4)
     xcpretty (0.3.0)
       rouge (~> 2.0.7)
-    zeitwerk (2.5.1)
 
 PLATFORMS
   universal-darwin-21
@@ -111,7 +109,7 @@ PLATFORMS
 DEPENDENCIES
   bacon
   bundler (> 1.3)
-  cocoapods (~> 1.11.2)
+  cocoapods (~> 1.12.1)
   cocoapods-binary!
   mocha
   mocha-on-bacon
@@ -119,4 +117,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   2.2.15
+   2.2.22

--- a/cocoapods-binary.gemspec
+++ b/cocoapods-binary.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency "cocoapods", "~> 1.11.2"
+  spec.add_dependency "cocoapods", "~> 1.12.1"
   spec.add_dependency "fourflusher", "~> 2.0"
   spec.add_dependency "xcpretty", "~> 0.3.0"
 


### PR DESCRIPTION
This PR updates the version of Cocoapods to 1.12.1. This is required to allow compilation in Xcode 14.3.